### PR TITLE
Support higher limit/offset than available items

### DIFF
--- a/srfi/memory.scm
+++ b/srfi/memory.scm
@@ -29,6 +29,23 @@
         (loop (+ index 1)
               (cons (bytevector-u8-ref bv index) out)))))
 
+(define (take-upto items limit)
+  (let loop ((items items)
+             (i 0)
+             (acc '()))
+    (cond
+     ((null? items) (reverse acc))
+     ((< i limit) (loop (cdr items) (+ i 1) (cons (car items) acc)))
+     (else (reverse acc)))))
+
+(define (drop-upto items limit)
+  (let loop ((items items)
+             (i 0))
+    (cond
+     ((null? items) items)
+     ((< i limit) (loop (cdr items) (+ i 1)))
+     (else items))))
+
 ;;
 ;; This a memory based okvs implementation backed by the r7rs
 ;; library (scheme mapping). Roll-back operation is supported.
@@ -195,9 +212,9 @@
       (unless reverse?
         (set! lst (reverse lst)))
       (when offset
-        (set! lst (drop lst offset)))
+        (set! lst (drop-upto lst offset)))
       (when limit
-        (set! lst (take lst limit)))
+        (set! lst (take-upto lst limit)))
       lst)))
 
 (define (okvs-range okvs-or-transaction start-key start-include? end-key end-include? . config)

--- a/srfi/memory/test.sld
+++ b/srfi/memory/test.sld
@@ -162,6 +162,43 @@
            out)))
 
       (test
+       '(
+         (#u8(20 16 01) . #u8(2))
+         (#u8(20 17 01) . #u8(2))
+         )
+       (let ((okvs (engine-open engine #f)))
+         ;; set
+         (engine-in-transaction engine okvs
+                                (lambda (transaction)
+                                  (engine-set! engine transaction #u8(20 17 01) #u8(2))
+                                  (engine-set! engine transaction #u8(20 16 01) #u8(2))))
+         ;; get
+         (let ((out (engine-in-transaction engine okvs
+                                           (lambda (transaction)
+                                             (generator->list (engine-prefix-range engine transaction
+                                                                                   #u8(20)
+                                                                                   '((limit . 3))))))))
+           (engine-close engine okvs)
+           out)))
+
+      (test
+       '()
+       (let ((okvs (engine-open engine #f)))
+         ;; set
+         (engine-in-transaction engine okvs
+                                (lambda (transaction)
+                                  (engine-set! engine transaction #u8(20 17 01) #u8(2))
+                                  (engine-set! engine transaction #u8(20 16 01) #u8(2))))
+         ;; get
+         (let ((out (engine-in-transaction engine okvs
+                                           (lambda (transaction)
+                                             (generator->list (engine-prefix-range engine transaction
+                                                                                   #u8(20)
+                                                                                   '((offset . 3))))))))
+           (engine-close engine okvs)
+           out)))
+
+      (test
        '()
        (let ((keys '(#u8(1 42 0 20 2 55 97 98 53 118 54 110 103 113 119 49 117 53 121 111 57 50 104 110 107 105 109 112 105 104 0 21 102 21 103)
                          #u8(1 42 0 21 1 21 102 21 103 2 55 97 98 53 118 54 110 103 113 119 49 117 53 121 111 57 50 104 110 107 105 109 112 105 104 0)


### PR DESCRIPTION
This simulates behavior like in a RDBMS where using LIMIT/OFFSET with a higher number than available items doesn't error out.