### PR TITLE
Support empty prefix in okvs-prefix-range

### DIFF
--- a/srfi/memory.scm
+++ b/srfi/memory.scm
@@ -233,7 +233,12 @@
     (u8-list->bytevector (reverse (cons (+ 1 (car bytes)) (cdr bytes))))))
 
 (define (okvs-prefix-range okvs-or-transaction prefix . config)
-  (apply okvs-range okvs-or-transaction prefix #t (strinc prefix) #f config))
+  (if (zero? (bytevector-length prefix))
+      (let* ((store (okvs-transaction-store okvs-or-transaction))
+             (min-key (mapping-min-key store))
+             (max-key (mapping-max-key store)))
+        (apply okvs-range okvs-or-transaction min-key #t max-key #t config))
+      (apply okvs-range okvs-or-transaction prefix #t (strinc prefix) #f config)))
 
 (define (make-default-engine)
   (make-engine okvs-open

--- a/srfi/memory/test.sld
+++ b/srfi/memory/test.sld
@@ -114,6 +114,30 @@
            out)))
 
       (test
+       '((#u8(01 02) . #u8(1))
+         (#u8(20 16) . #u8(2))
+         (#u8(20 16 1) . #u8(2))
+         (#u8(20 17) . #u8(3))
+         (#u8(20 17 1) . #u8(2))
+         (#u8(42 42) . #u8(5)))
+       (let ((okvs (engine-open engine #f)))
+         ;; set
+         (engine-in-transaction engine okvs
+                                (lambda (transaction)
+                                  (engine-set! engine transaction #u8(20 17 01) #u8(2))
+                                  (engine-set! engine transaction #u8(20 17) #u8(3))
+                                  (engine-set! engine transaction #u8(42 42) #u8(5))
+                                  (engine-set! engine transaction #u8(01 02) #u8(1))
+                                  (engine-set! engine transaction #u8(20 16) #u8(2))
+                                  (engine-set! engine transaction #u8(20 16 01) #u8(2))))
+         ;; get
+         (let ((out (engine-in-transaction engine okvs
+                                           (lambda (transaction)
+                                             (generator->list (engine-prefix-range engine transaction #u8()))))))
+           (engine-close engine okvs)
+           out)))
+
+      (test
        '((#u8(20 16) . #u8(2))
          (#u8(20 16 1) . #u8(2))
          (#u8(20 17) . #u8(3))


### PR DESCRIPTION
Currently supplying an empty prefix range raises an error from strinc instead of returning all items.